### PR TITLE
Ticket4694 test readonly and disp

### DIFF
--- a/iocBoot/iocsimple/st.cmd
+++ b/iocBoot/iocsimple/st.cmd
@@ -17,7 +17,7 @@ simple_registerRecordDeviceDriver pdbbase
 
 < $(IOCSTARTUP)/dbload.cmd
 
-dbLoadRecords("db/simple.db","P=$(MYPVPREFIX)SIMPLE:, ASG=READONLY")
+dbLoadRecords("db/simple.db","P=$(MYPVPREFIX)SIMPLE:")
 dbLoadRecords("db/channel_access_test.db","P=$(MYPVPREFIX)SIMPLE:")
 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/iocBoot/iocsimple/st.cmd
+++ b/iocBoot/iocsimple/st.cmd
@@ -17,7 +17,8 @@ simple_registerRecordDeviceDriver pdbbase
 
 < $(IOCSTARTUP)/dbload.cmd
 
-dbLoadRecords("db/simple.db","P=$(MYPVPREFIX)SIMPLE:")
+dbLoadRecords("db/simple.db","P=$(MYPVPREFIX)SIMPLE:, ASG=READONLY")
+dbLoadRecords("db/channel_access_test.db","P=$(MYPVPREFIX)SIMPLE:")
 
 < $(IOCSTARTUP)/preiocinit.cmd
 
@@ -26,3 +27,4 @@ iocInit
 
 < $(IOCSTARTUP)/postiocinit.cmd
 
+dbl

--- a/iocBoot/iocsimple/st.cmd
+++ b/iocBoot/iocsimple/st.cmd
@@ -26,5 +26,3 @@ cd ${TOP}/iocBoot/${IOC}
 iocInit
 
 < $(IOCSTARTUP)/postiocinit.cmd
-
-dbl

--- a/simpleApp/Db/Makefile
+++ b/simpleApp/Db/Makefile
@@ -10,7 +10,7 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------------------
 # Create and install (or just install) into <top>/db
 # databases, templates, substitutions like this
-DB += simple.db
+DB += simple.db channel_access_test.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/simpleApp/Db/channel_access_test.substitutions
+++ b/simpleApp/Db/channel_access_test.substitutions
@@ -1,0 +1,13 @@
+file "channel_access_test.template" {
+    pattern{P, RECORD_TYPE, RECORD_NAME, ISB, ISMBB}
+    {"\$(P)", bo, BO, " ", "#"}
+    {"\$(P)", bi, BI, " ", "#"}
+    {"\$(P)", mbbi, MBBI, "#", " "}
+    {"\$(P)", mbbo, MBBO, "#", " "}
+    {"\$(P)", ao, AO, "#", "#"}
+    {"\$(P)", ai, AI, "#", "#"}
+    {"\$(P)", stringin, STRINGIN, "#", "#"}
+    {"\$(P)", stringout, STRINGOUT, "#", "#"}
+    {"\$(P)", calc, CALC, "#", "#"}
+    {"\$(P)", calcout, CALCOUT, "#", "#"}
+}

--- a/simpleApp/Db/channel_access_test.template
+++ b/simpleApp/Db/channel_access_test.template
@@ -3,29 +3,38 @@ record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):RO")
 {
     field(ASG, "READONLY")
     field(VAL, "0")
+    field(SCAN, "Passive")
 $(ISB)   field(ZNAM, "OFF")
 $(ISB)   field(ONAM, "ON")
-#$(ISMBB)   field(ZRVL, "OFF")
-#$(ISMBB)   field(ONVL, "ON")
+$(ISMBB)   field(ZRVL, "0")
+$(ISMBB)   field(ONVL, "1")
+$(ISMBB)   field(ZRST, "OFF")
+$(ISMBB)   field(ONST, "ON")
 }
 record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):DISP")
 {
     field(DISP, "1")
     field(VAL, "0")
+    field(SCAN, "Passive")
 $(ISB)   field(ZNAM, "OFF")
 $(ISB)   field(ONAM, "ON")
-#$(ISMBB)   field(ZRVL, "OFF")
-#$(ISMBB)   field(ONVL, "ON")
+$(ISMBB)   field(ZRVL, "0")
+$(ISMBB)   field(ONVL, "1")
+$(ISMBB)   field(ZRST, "OFF")
+$(ISMBB)   field(ONST, "ON")
 }
 record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):RODISP")
 {
     field(ASG, "READONLY")
     field(DISP, "1")
     field(VAL, "0")
+    field(SCAN, "Passive")
 $(ISB)   field(ZNAM, "OFF")
 $(ISB)   field(ONAM, "ON")
-#$(ISMBB)   field(ZRVL, "OFF")
-#$(ISMBB)   field(ONVL, "ON")
+$(ISMBB)   field(ZRVL, "0")
+$(ISMBB)   field(ONVL, "1")
+$(ISMBB)   field(ZRST, "OFF")
+$(ISMBB)   field(ONST, "ON")
 }
 record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):HIDDEN")
 {
@@ -34,20 +43,22 @@ record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):HIDDEN")
     field(VAL, "0")
 $(ISB)   field(ZNAM, "OFF")
 $(ISB)   field(ONAM, "ON")
-#$(ISMBB)   field(ZRVL, "OFF")
-#$(ISMBB)   field(ONVL, "ON")
+$(ISMBB)   field(ZRVL, "0")
+$(ISMBB)   field(ONVL, "1")
+$(ISMBB)   field(ZRST, "OFF")
+$(ISMBB)   field(ONST, "ON")
 }
 
 
-record($(RECORD_TYPE), "$(P)TESTRECORD:$(RECORD_NAME):RO:FLNK")
+record(ao, "$(P)CATEST:$(RECORD_NAME):RO:OUT")
 {
-    field(FLNK, "$(P)CATEST:$(RECORD_NAME):RO")
+    field(OUT, "$(P)CATEST:$(RECORD_NAME):RO")
 }
-record($(RECORD_TYPE), "$(P)TESTRECORD:$(RECORD_NAME):DISP:FLNK")
+record(ao, "$(P)CATEST:$(RECORD_NAME):DISP:OUT")
 {
-    field(FLNK, "$(P)CATEST:$(RECORD_NAME):DISP")
+    field(OUT, "$(P)CATEST:$(RECORD_NAME):DISP")
 }
-record($(RECORD_TYPE), "$(P)TESTRECORD:$(RECORD_NAME):RODISP:FLNK")
+record(ao, "$(P)CATEST:$(RECORD_NAME):RODISP:OUT")
 {
-    field(FLNK, "$(P)CATEST:$(RECORD_NAME):RODISP")
+    field(OUT, "$(P)CATEST:$(RECORD_NAME):RODISP")
 }

--- a/simpleApp/Db/channel_access_test.template
+++ b/simpleApp/Db/channel_access_test.template
@@ -62,3 +62,25 @@ record(ao, "$(P)CATEST:$(RECORD_NAME):RODISP:OUT")
 {
     field(OUT, "$(P)CATEST:$(RECORD_NAME):RODISP")
 }
+
+record(calcout, "$(P)CATEST:$(RECORD_NAME):RO:PROC")
+{
+    field(INPA, "$(P)CATEST:$(RECORD_NAME):RO:OUT.PROC")
+    field(CALC, "A=1?0:1")
+    field(VAL, "0")
+    field(CALC, "1")
+}
+record(calcout, "$(P)CATEST:$(RECORD_NAME):DISP:PROC")
+{
+    field(INPA, "$(P)CATEST:$(RECORD_NAME):DISP:OUT.PROC")
+    field(CALC, "A=1?0:1")
+    field(VAL, "0")
+    field(CALC, "1")
+}
+record(calcout, "$(P)CATEST:$(RECORD_NAME):RODISP:PROC")
+{
+    field(INPA, "$(P)CATEST:$(RECORD_NAME):RODISP:OUT.PROC")
+    field(CALC, "A=1?0:1")
+    field(VAL, "0")
+    field(CALC, "1")
+}

--- a/simpleApp/Db/channel_access_test.template
+++ b/simpleApp/Db/channel_access_test.template
@@ -1,0 +1,53 @@
+
+record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):RO")
+{
+    field(ASG, "READONLY")
+    field(VAL, "0")
+$(ISB)   field(ZNAM, "OFF")
+$(ISB)   field(ONAM, "ON")
+#$(ISMBB)   field(ZRVL, "OFF")
+#$(ISMBB)   field(ONVL, "ON")
+}
+record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):DISP")
+{
+    field(DISP, "1")
+    field(VAL, "0")
+$(ISB)   field(ZNAM, "OFF")
+$(ISB)   field(ONAM, "ON")
+#$(ISMBB)   field(ZRVL, "OFF")
+#$(ISMBB)   field(ONVL, "ON")
+}
+record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):RODISP")
+{
+    field(ASG, "READONLY")
+    field(DISP, "1")
+    field(VAL, "0")
+$(ISB)   field(ZNAM, "OFF")
+$(ISB)   field(ONAM, "ON")
+#$(ISMBB)   field(ZRVL, "OFF")
+#$(ISMBB)   field(ONVL, "ON")
+}
+record($(RECORD_TYPE), "$(P)CATEST:$(RECORD_NAME):HIDDEN")
+{
+    field(ASG, "HIDDEN")
+    field(DISP, "1")
+    field(VAL, "0")
+$(ISB)   field(ZNAM, "OFF")
+$(ISB)   field(ONAM, "ON")
+#$(ISMBB)   field(ZRVL, "OFF")
+#$(ISMBB)   field(ONVL, "ON")
+}
+
+
+record($(RECORD_TYPE), "$(P)TESTRECORD:$(RECORD_NAME):RO:FLNK")
+{
+    field(FLNK, "$(P)CATEST:$(RECORD_NAME):RO")
+}
+record($(RECORD_TYPE), "$(P)TESTRECORD:$(RECORD_NAME):DISP:FLNK")
+{
+    field(FLNK, "$(P)CATEST:$(RECORD_NAME):DISP")
+}
+record($(RECORD_TYPE), "$(P)TESTRECORD:$(RECORD_NAME):RODISP:FLNK")
+{
+    field(FLNK, "$(P)CATEST:$(RECORD_NAME):RODISP")
+}


### PR DESCRIPTION
Added new template/substitution file to test for record protection as per [ticket 4694](https://github.com/ISISComputingGroup/IBEX/issues/4694). There is a new set of records for each of ai, ao, bi, bo, mbbi, mbbo, stringin, stringout, calc and calcout which are used to monitor whether pur methods of protecting files are rigorous enough, as outlined in [another pull request in this ticket](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/230).